### PR TITLE
Fix/lifocallbacks

### DIFF
--- a/plugin/includes/callbacks.h
+++ b/plugin/includes/callbacks.h
@@ -12,7 +12,7 @@ typedef struct _Callback Callback;
 typedef struct _Runner Runner;
 typedef struct _CallbackInvocation CallbackInvocation;
 
-typedef void (*CALLBACK_FUNCTION)(struct Runner* runner, struct CallbackInvocation* callback);
+typedef void (*CALLBACK_FUNCTION)(Runner* runner, CallbackInvocation* callback);
 
 struct _Runner {
 	CALLBACK_FUNCTION callbackEnterFunction;

--- a/plugin/includes/callbacks.h
+++ b/plugin/includes/callbacks.h
@@ -8,32 +8,34 @@
 #include "pharoSemaphore.h"
 #include "pSemaphore.h"
 
-struct _Callback;
-struct _Runner;
-struct _CallbackInvocation;
+typedef struct _Callback Callback;
+typedef struct _Runner Runner;
+typedef struct _CallbackInvocation CallbackInvocation;
 
-typedef void (*CALLBACK_FUNCTION)(struct _Runner* runner, struct _CallbackInvocation* callback);
+typedef void (*CALLBACK_FUNCTION)(struct Runner* runner, struct CallbackInvocation* callback);
 
-typedef struct _Runner {
+struct _Runner {
 	CALLBACK_FUNCTION callbackEnterFunction;
 	CALLBACK_FUNCTION callbackExitFunction;
-} Runner;
+    CallbackInvocation *callbackStack;
+};
 
-typedef struct _Callback {
+struct _Callback {
     Runner* runner;
     ffi_closure *closure;
     ffi_cif cif;
     void *functionAddress;
     ffi_type **parameterTypes;
-} Callback;
+};
 
-typedef struct _CallbackInvocation {
+struct _CallbackInvocation {
     Callback *callback;
     void *returnHolder;
     void **arguments;
     //Optional payload used by the runners
     void *payload;
-} CallbackInvocation;
+    void *previous;
+};
 
 Callback *callback_new(Runner * runner, ffi_type** parameters, sqInt count, ffi_type* returnType);
 void callback_release(Callback* callbackData);

--- a/plugin/includes/threadSafeQueue.h
+++ b/plugin/includes/threadSafeQueue.h
@@ -6,6 +6,7 @@
 typedef struct __TSQueue TSQueue;
 
 TSQueue *threadsafe_queue_new(Semaphore *semaphore);
+int threadsafe_queue_size(TSQueue *queue);
 void threadsafe_queue_put(TSQueue *queue, void *element);
 void *threadsafe_queue_take(TSQueue *queue);
 void threadsafe_queue_free(TSQueue *queue);

--- a/plugin/src/callbacks/callbacks.c
+++ b/plugin/src/callbacks/callbacks.c
@@ -18,7 +18,13 @@ static void callbackFrontend(ffi_cif *cif, void *ret, void* args[], void* cbPtr)
 	invocation.callback = callback;
 	invocation.arguments = args;
 	invocation.returnHolder = ret;
-	queue_add_pending_callback(&invocation);
+    
+    // Push callback invocation into a callback stack
+    // This callback stack is used to validate that callbacks return in order
+    invocation.previous = callback->runner->callbackStack;
+    callback->runner->callbackStack = &invocation;
+    
+    queue_add_pending_callback(&invocation);
 	
 	// Manage callouts while waiting this callback to return
 	callback->runner->callbackEnterFunction(callback->runner, &invocation);

--- a/plugin/src/queue/threadSafeQueue.c
+++ b/plugin/src/queue/threadSafeQueue.c
@@ -63,6 +63,22 @@ void threadsafe_queue_free(TSQueue *queue) {
 }
 
 /**
+ *  Return the number of elements in the queue
+ **/
+int threadsafe_queue_size(TSQueue *queue) {
+    int size = 0;
+    TSQueueNode *node;
+    pthread_mutex_lock(&(queue->mutex));
+    node = queue->first;
+    while(node){
+        size++;
+        node = node->next;
+    }
+    pthread_mutex_unlock(&(queue->mutex));
+    return size;
+}
+
+/**
  *  Put an element at the end of in the thread safe queue
  *  Only one process may modify the queue at a single point in time
  *  Allocates a new node and puts the element into it

--- a/plugin/src/sameThread/sameThread.c
+++ b/plugin/src/sameThread/sameThread.c
@@ -28,7 +28,8 @@ void sameThreadCallbackExit(struct _Runner* runner, struct _CallbackInvocation* 
 
 static Runner sameThreadRunner = {
 	sameThreadCallbackEnter,
-	sameThreadCallbackExit
+	sameThreadCallbackExit,
+    NULL
 };
 
 /* primitivePerformWorkerCall

--- a/plugin/src/worker/worker.c
+++ b/plugin/src/worker/worker.c
@@ -48,6 +48,7 @@ Worker *worker_newSpawning(int spawn) {
     worker->taskQueue = threadsafe_queue_new(platform_semaphore_new(0));
     worker->runner.callbackEnterFunction = worker_enter_callback;
     worker->runner.callbackExitFunction = worker_callback_return;
+    worker->runner.callbackStack = NULL;
 
     if(spawn){
     	if (pthread_create(&(worker->threadId), NULL, worker_run, (void *)worker) != 0) {


### PR DESCRIPTION
Callback return should not return if not the last callback in the thread.
For this we keep a stack of incoming callbacks per-runner.
On a callback, we add the callback invocation to the stack.
When a callback returns, we verify it is the last in the queue, if not, we fail the primitive.