### PR TITLE
Modify ExternalData>>readStringUTF8 so that it is forgiving 

### DIFF
--- a/src/UnifiedFFI/ExternalData.extension.st
+++ b/src/UnifiedFFI/ExternalData.extension.st
@@ -35,9 +35,10 @@ ExternalData >> readString [
 { #category : #'*UnifiedFFI' }
 ExternalData >> readStringUTF8 [
 	"Assume that the receiver represents a C string containing UTF8 characters and convert 
-	 it to a Smalltalk string."
-	| stream index char |
-	
+	 it to a Smalltalk string.
+	If the conversion fails, use the null encoding"
+	| stream index char bytes |
+
 	self isNull ifTrue: [ ^ nil ].
 	
 	type isPointerType ifFalse: [self error: 'External object is not a pointer type.'].
@@ -46,7 +47,10 @@ ExternalData >> readStringUTF8 [
 	[(char := handle unsignedByteAt: index) = 0 ] whileFalse: [
 		stream nextPut: char.
 		index := index + 1].
-	^ ZnCharacterEncoder utf8 decodeBytes: stream contents
+	^ [ ZnCharacterEncoder utf8 decodeBytes: (bytes := stream contents) ]
+		on: ZnInvalidUTF8 
+		do: [ bytes asString ]
+
 ]
 
 { #category : #'*UnifiedFFI' }


### PR DESCRIPTION
if the string is not valid UTF8

Fixes: https://github.com/pharo-project/pharo/issues/4650