### PR TITLE
Fix tests in Pharo8

### DIFF
--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIMarshallingInCallbacksTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIMarshallingInCallbacksTest.class.st
@@ -47,7 +47,7 @@ TFUFFIMarshallingInCallbacksTest >> call: aName type: aType value: aValue [
 { #category : #tests }
 TFUFFIMarshallingInCallbacksTest >> call: aName value: aValue [
 
-	^ self call: aName type: { aName } value: aValue
+	^ self call: aName type: { aName asSymbol } value: aValue
 ]
 
 { #category : #'ffi-calls' }


### PR DESCRIPTION
New UFFI requires types to be symbols and not strings. Strings are string literals.
This change makes all tests green