### PR TITLE
TFBooleanType>>basicType should use uint8, not ushort

### DIFF
--- a/src/ThreadedFFI/TFBooleanType.class.st
+++ b/src/ThreadedFFI/TFBooleanType.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #accessing }
 TFBooleanType >> basicType [
 	
-	^ TFBasicType ushort
+	^ TFBasicType uint8
 ]
 
 { #category : #'reading-writing' }


### PR DESCRIPTION
It looks like TFBooleanType is incorrectly defined:

TFBooleanType>>basicType
    
    ^ TFBasicType ushort


which is 16 bits, while booleans in C are 8 bits.  (This caused one of our automated tests to fail.  Interestingly, it only fails with the optimised version of the binary, the debug version passes).

Replacing it with:

TFBooleanType>>basicType
    
    ^ TFBasicType uint8


produces the correct behaviour.