### PR TITLE
Add support for building the plugin with GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -1,0 +1,107 @@
+name: Continuous integration
+on: [push, pull_request]
+
+jobs:
+    build-unixes:
+        name: Build Unixes
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-18.04, macos-latest]
+        env:
+            CC: gcc
+            CXX: g++
+        steps:
+            - name: Install dependencies
+              if: matrix.os == 'macos-latest'
+              run: brew install gcc autoconf automake libtool
+
+            - uses: actions/checkout@v1
+
+            - name: CMake configuration
+              run: cmake .
+
+            - name: make
+              run: make
+            - name: make install
+              run: make install
+
+            - name: Package artifacts
+              run: |
+                make package
+                mkdir -p artifacts
+                cp -f build/packages/*.zip build/packages/*.sha1 artifacts
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v1
+              with:
+                  name: build-artifacts
+                  path: artifacts
+
+            - name: Run tests
+              continue-on-error: true
+              run: |
+                make test
+                mkdir -p test-results
+                cp -f build/test/*.xml test-results
+            - name: Upload test results
+              continue-on-error: true
+              uses: actions/upload-artifact@v1
+              with:
+                  name: test-results
+                  path: test-results
+
+    build-windows-cygwin:
+        name: Build Windows Cygwin
+        runs-on: windows-2016
+        steps:
+            - uses: actions/checkout@v1
+
+            - name: Install Cygwin
+              run: .\scripts\installCygwin.ps1 "setup-x86_64.exe" x86_64
+
+            - name: Cygwin test
+              run: |
+                echo Testing cygwin
+                x86_64-w64-mingw32-gcc --version
+                x86_64-w64-mingw32-g++ --version
+                cmake --version
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+
+            - name: CMake configuration
+              run: cmake .
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+
+            - name: make
+              run: make
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+            - name: make install
+              run: make install
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+
+            - name: Package artifacts
+              run: |
+                make package
+                mkdir -p artifacts
+                cp -f build/packages/*.zip build/packages/*.sha1 artifacts
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v1
+              with:
+                  name: build-artifacts
+                  path: artifacts
+
+            - name: Run tests
+              continue-on-error: true
+              run: |
+                make test
+                mkdir -p test-results
+                cp -f build/test/*.xml test-results
+              shell: pwsh.exe -File .\scripts\runScriptInCygwinBash.ps1 {0}
+
+            - name: Upload test results
+              continue-on-error: true
+              uses: actions/upload-artifact@v1
+              with:
+                  name: test-results
+                  path: test-results

--- a/scripts/installCygwin.ps1
+++ b/scripts/installCygwin.ps1
@@ -1,0 +1,38 @@
+# Stop on errors
+$ErrorActionPreference = 'stop'
+
+# Parse some arguments and set some variables.
+$installerName = $args[0]
+$cygwinArch = $args[1]
+$installerURL = "http://cygwin.com/$installerName"
+$cygwinRoot = 'c:\cygwin'
+$cygwinMirror ="http://cygwin.mirror.constant.com"
+
+# Download the cygwin installer.
+echo "Downloading the Cygwin installer from $installerURL"
+Invoke-WebRequest -UseBasicParsing -URI "$installerURL" -OutFile "$installerName"
+
+# Install cygwin and the required packages.
+echo "Installing Cygwin packages"
+& ".\$installerName" -dgnqNO -R "$cygwinRoot" -s "$cygwinMirror" -l "$cygwinRoot\var\cache\setup" `
+    -P make `
+    -P cmake `
+    -P zip `
+    -P binutils `
+    -P gcc-core `
+    -P gcc-g++ `
+    -P mingw64-$cygwinArch-binutils `
+    -P mingw64-$cygwinArch-gcc-core `
+    -P mingw64-$cygwinArch-gcc-g++ `
+    -P unzip `
+    -P wget `
+    -P git `
+    -P patch `
+    -P autoconf `
+    -P autoconf2.5 `
+    -P automake `
+    -P automake1.16 `
+    -P libtool `
+    -P curl | Out-Null
+
+echo "Cygwin installed under $cygwinRoot"

--- a/scripts/runScriptInCygwinBash.ps1
+++ b/scripts/runScriptInCygwinBash.ps1
@@ -1,0 +1,30 @@
+# Stop on errors
+$ErrorActionPreference = 'stop'
+
+# The script name
+$scriptFileName = $args[0]
+$cygwinRoot = 'c:\cygwin'
+$bashExecutable ="$cygwinRoot\bin\bash.exe"
+
+# Create a modified version of the script.
+$scriptContent = Get-Content -Path $scriptFileName | Out-String
+$modifiedScriptFileName = "$(New-TemporaryFile).sh"
+$cygwinModifiedScriptFileName = & "$cygwinRoot\bin\cygpath.exe" "$modifiedScriptFileName"
+$cygwinCWD = & "$cygwinRoot\bin\cygpath.exe" (Get-Location)
+$modifiedScriptContent = "#!/bin/bash --login
+cd $cygwinCWD
+export PATH=`"/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows/system32/Wbem`"
+set -ex
+
+$scriptContent
+".Replace("`r`n","`n")
+
+Out-File -Encoding ASCII -NoNewline -InputObject $modifiedScriptContent $modifiedScriptFileName
+
+# Run the modified script.
+& $bashExecutable $cygwinModifiedScriptFileName
+
+# Reflect the last exit code
+if ((Test-Path -LiteralPath variable:\LASTEXITCODE)) {
+    exit $LASTEXITCODE
+}


### PR DESCRIPTION
This commit adds support for building the plugin and running the tests under GitHub Actions. This is equivalent to using Travis and AppVeyor, but in a single system. In feenk we are using GitHub actions because there are few cloud services that provide OS X VMs for setting Jenkins. This also helps on building and testing in a local fork before doing a pull request.