### PR TITLE
Update to be compatible with latest Pharo800 changes

### DIFF
--- a/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
+++ b/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
@@ -50,7 +50,7 @@ TFCalloutMethodBuilder >> generateFFICallout: builder spec: functionSpec [
 	"save ffi call as literal"
 	builder pushLiteral: (self createFFICalloutLiteralFromSpec: functionSpec).
 	"iterate arguments in order (in the function) to create the function call"
-	functionSpec arguments do: [ :each | each emitArgument: builder context: sender ].
+	functionSpec arguments do: [ :each | each emitArgument: builder context: sender inCallout: self requestor ].
 	"create the array"
 	builder pushConsArray: functionSpec arguments size.
 	"send call and store into result"
@@ -58,5 +58,9 @@ TFCalloutMethodBuilder >> generateFFICallout: builder spec: functionSpec [
 	
 	functionSpec arguments do: [ :each | each emitReturnArgument: builder context: sender ].
 	"convert in case return type needs it. And return reseult"
-	^ functionSpec returnType emitReturn: builder resultTempVar: #result context: sender
+	^ functionSpec returnType
+		emitReturn: builder
+		resultTempVar: #result
+		context: sender
+		inCallout: self requestor
 ]


### PR DESCRIPTION
Fix threadedFFI to be compatible with the latest changes in Pharo800, related to string encodings.
Being able to encode strings requires that the callout context is sent as argument, to have access to the callout options during code generation.

This PR modifies TFFI method builder to send the callout in argument and return code generation.

Should fix #20 